### PR TITLE
Remove hardcoded paths from examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,7 @@ required-features = ["json", "image/default-formats"]
 [[example]]
 name = "wz_to_json"
 required-features = ["json"]
+
+[[example]]
+name = "parse_single_img_file"
+required-features = ["image/png"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,7 @@ required-features = ["json"]
 [[example]]
 name = "parse_single_img_file"
 required-features = ["image/png"]
+
+[[example]]
+name = "extracting_pngs"
+required-features = ["image/png"]

--- a/examples/extracting_pngs.rs
+++ b/examples/extracting_pngs.rs
@@ -3,6 +3,12 @@ use wz_reader::util::{resolve_base, resolve_root_wz_file_dir, walk_node};
 use wz_reader::{WzNode, WzNodeArc, WzNodeCast};
 
 fn main() {
+    let mut args = std::env::args().skip(1);
+    let method = args
+        .next()
+        .expect("Need method (single/base/folder) as 1st arg");
+    let path = args.next().expect("Need path to wz file as 2nd arg");
+    let out = args.next().expect("Need out dir as 3rd arg");
     let save_image_fn = |node: &WzNodeArc| {
         let node_read = node.read().unwrap();
         if node_read.try_as_png().is_some() {
@@ -10,27 +16,29 @@ fn main() {
             /* the name of image is easily got conflect */
             let save_name = node_read.get_full_path().replace("/", "-");
             /* resolving image will auto resolve image from _inlink and _outlink */
-            image.save(format!("./images/{save_name}.png")).unwrap();
+            image.save(format!("{out}/{save_name}.png")).unwrap();
         }
     };
+    match method.as_str() {
+        "single" => {
+            /* resolve single wz file */
+            let node: WzNodeArc = WzNode::from_wz_file(path, None).unwrap().into();
 
-    /* resolve single wz file */
-    let node: WzNodeArc =
-        WzNode::from_wz_file(r"D:\MapleStory\Data\Npc\_Canvas\_Canvas000.wz", None)
-            .unwrap()
-            .into();
+            walk_node(&node, true, &save_image_fn);
+        }
+        "base" => {
+            /* resolve from base.wz */
+            let base_node = resolve_base(&path, None).unwrap();
 
-    walk_node(&node, true, &save_image_fn);
+            /* this will take millions years */
+            walk_node(&base_node, true, &save_image_fn);
+        }
+        "folder" => {
+            /* resolve whole wz folder */
+            let root_node = resolve_root_wz_file_dir(&path, None).unwrap();
 
-    /* resolve from base.wz */
-    let base_node = resolve_base(r"D:\MapleStory\Data\Base.wz", None).unwrap();
-
-    /* this will take millions years */
-    walk_node(&base_node, true, &save_image_fn);
-
-    /* resolve whole wz folder */
-    let root_node =
-        resolve_root_wz_file_dir(r"D:\MapleStory\Data\Npc\_Canvas\_Canvas.wz", None).unwrap();
-
-    walk_node(&root_node, true, &save_image_fn);
+            walk_node(&root_node, true, &save_image_fn);
+        }
+        _ => eprintln!("Invalid method"),
+    }
 }

--- a/examples/parallel_parse_wz_image.rs
+++ b/examples/parallel_parse_wz_image.rs
@@ -2,9 +2,10 @@ use std::thread;
 use wz_reader::{WzNode, WzNodeArc};
 
 fn main() {
-    let node: WzNodeArc = WzNode::from_wz_file(r"D:\MapleStory\Data\UI\UI_000.wz", None)
-        .unwrap()
-        .into();
+    let path = std::env::args_os()
+        .nth(1)
+        .expect("Need path to .wz as first argument");
+    let node: WzNodeArc = WzNode::from_wz_file(path, None).unwrap().into();
 
     let mut node_write = node.write().unwrap();
 

--- a/examples/parse_single_img_file.rs
+++ b/examples/parse_single_img_file.rs
@@ -1,24 +1,23 @@
+use std::path::PathBuf;
+
 use wz_reader::property::get_image;
 use wz_reader::util::walk_node;
-use wz_reader::version::WzMapleVersion;
 use wz_reader::{WzNode, WzNodeArc, WzNodeCast};
 
 fn main() {
+    let mut args = std::env::args_os().skip(1);
+    let path = args.next().expect("Need .wz file as 1st argument");
+    let out_dir: PathBuf = args.next().expect("Need out dir as 2nd argument").into();
     /* resolve single img file */
-    let node: WzNodeArc = WzNode::from_img_file(
-        r"D:\MapleStory\Data\Item\_Canvas\_Canvas\5000024.img",
-        Some(WzMapleVersion::BMS),
-        None,
-    )
-    .unwrap()
-    .into();
+    let node: WzNodeArc = WzNode::from_img_file(path, None, None).unwrap().into();
 
     walk_node(&node, true, &|node: &WzNodeArc| {
         let node_read = node.read().unwrap();
         if node_read.try_as_png().is_some() {
-            let image = get_image(&node).unwrap();
-            let save_name = node_read.get_full_path().replace("/", "-");
-            image.save(format!("./images/{save_name}.png")).unwrap();
+            let image = get_image(&node).unwrap().into_rgba8();
+            let save_name = [&node_read.get_full_path().replace("/", "-"), ".png"].concat();
+            let out_path = out_dir.join(save_name);
+            image.save(out_path).unwrap();
         }
     });
 }

--- a/examples/single_file.rs
+++ b/examples/single_file.rs
@@ -2,10 +2,11 @@ use wz_reader::util::walk_node;
 use wz_reader::{WzNode, WzNodeArc};
 
 fn main() {
+    let path = std::env::args_os()
+        .nth(1)
+        .expect("Need .wz file as argument");
     /* resolve single wz file */
-    let node: WzNodeArc = WzNode::from_wz_file(r"D:\MapleStory\Data\UI\UI_000.wz", None)
-        .unwrap()
-        .into();
+    let node: WzNodeArc = WzNode::from_wz_file(path, None).unwrap().into();
 
     /*
         when you know exactly know what version is, consider using WzNode::from_wz_file_full


### PR DESCRIPTION
This makes it easier to try out the examples, especially on non-windows systems.

Also adds `image/png` feature requirement for examples that need it.